### PR TITLE
Add shadcn/ui reference and expand TODO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Rust
+/target/
+**/*.rs.bk
+
+# Node
+node_modules/
+.npm/
+
+# Logs
+*.log
+
+# IDE
+.idea/
+.vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Repo Guidelines for Codex Agents
+
+Welcome! This repository currently contains documentation only. As the project grows, code and tests will be added.
+
+## Programmatic Checks
+- If a `Cargo.toml` file exists, run `cargo test`.
+- If a `package.json` file exists, run `npm test`.
+- If neither exists, no checks are required.
+
+## Documentation Style
+- Keep lines under 120 characters when possible.
+- Use Markdown headings and lists where appropriate.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+- Initial documentation and repository scaffolding.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant](https://www.contributor-covenant.org/) version 2.1.
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our project and our community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints
+* Gracefully accepting constructive criticism
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the maintainers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to LittleFaith
+
+Thank you for considering contributing to LittleFaith!
+
+## Development Setup
+
+1. Install [Rust](https://www.rust-lang.org/) and [Node.js](https://nodejs.org/).
+2. Clone the repository and install JavaScript dependencies with `npm install` if a `package.json` exists.
+3. Build the desktop app using `cargo tauri dev`.
+
+## Pull Requests
+
+* Keep PRs focused and describe your changes clearly.
+* For code changes, add tests where possible.
+* Ensure `cargo test` and `npm test` pass before submitting.
+
+## Communication
+
+Feel free to open discussions or issues for questions and suggestions.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
 # LittleFaith
-Little Faith Library Engine &amp; Bible Software
+
+LittleFaith is a compact library engine and Bible software that blends desktop-first usability with web-friendly technologies.
+
+## Tech-Stack Quick-Glance
+("Desktop-first ❤️, web-friendly ✨, MIT-clean ✓")
+
+### 1. Runtime & UI
+
+| Layer         | Choice                                                        | Why it fits                                                                             |
+| ------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| **Container** | **Tauri 2** (Rust core + system WebView)                     | Tiny binaries (8‑15 MB), 50‑70 % less RAM than Electron, MIT-friendly, easy auto‑update |
+| **Frontend**  | **React 19** + **Vite** + **Radix UI** + **shadcn/ui**                       | Rich component ecosystem, hot‑reload, SSR/CSR toggles for future web build              |
+| **Styling**   | Tailwind CSS + shadcn/ui components                                  | Rapid kawaii theming, dark/light built‑in                                               |
+| **State**     | React Query + Zustand                                         | Decoupled async fetch + lightweight global state                                        |
+
+### 2. Core Logic
+
+| Domain             | Crate / Lib                        | Role                                                         |
+| ------------------ | ---------------------------------- | ------------------------------------------------------------ |
+| Text Engine        | **Rust** crate `littlefaith-core`  | OSIS → SQLite compiler, verse lookup, search API             |
+| Search             | SQLite FTS5 (desktop) → switchable to Tantivy | Millisecond full-text; plug-in swap later for huge libraries |
+| Data Sync (opt-in) | `littlefaith-sync` (Rust) w/ Dropbox Web‑API | JSON-delta + AES-CBC encryption of user vault                |
+
+### 3. Storage Layout
+
+```
+%APPDATA%/LittleFaith/
+ ├─ Modules/        (read-only .bbmod SQLite bundles)
+ ├─ UserVault.db    (notes/highlights/journal – encrypted)
+ └─ Cache/          (thumbnail & search indexes)
+```
+
+### 4. Plugin Surface
+
+```
+trait LittleFaithPlugin {
+    fn manifest(&self) -> PluginManifest;
+    fn register(api: &mut CoreApi);
+}
+```
+
+Rust dynamic-load or WASI. Examples: AI-chat assistant, Qur'an module, map viewer.
+
+### 5. Build & CI
+
+* **Cargo** workspaces → `cargo tauri build`
+* **Vitest + Jest** for UI tests
+* GitHub Actions: lint, unit-tests, cross-compile (Win/macOS/Linux), notarize Mac.
+
+### 6. Release Footprint
+
+* **Windows**: `LittleFaith-Setup-x64.exe` ≈ 12 MB
+* **macOS**: `.dmg` signed, universal 14 MB
+* **Linux**: `.AppImage` 13 MB
+
+### 7. Road to Web & Mobile
+
+* **Web**: Same React code in Vite → deploy as PWA; point to WASM-compiled `littlefaith-core` (via `wasm-pack`).
+* **Mobile**: Capacitor wrapper later; or Flutter rewrite if full native is desired.
+
+---
+
+LittleFaith aims for minimal footprint today with cathedral-level extensibility tomorrow.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,59 @@
+# LittleFaith – Phase-0 TODO  🍇✨
+_Desktop-first, Rust-powered, React-cute (Tailwind + shadcn/ui)._ 
+
+## 0️⃣ Meta / House-keeping
+- [x] 💖 Add `LICENSE` (MIT) at repo root.
+- [ ] 🏷️ Configure **Cargo workspaces** + **pnpm** monorepo (`/core`, `/frontend`).
+- [ ] 🤖 Prettier + ESLint + Rustfmt + Clippy CI gates.
+- [ ] 🔖 Define semantic versioning & branch naming (e.g. `main`, `feat/*`).
+- [ ] 🧪 Set up **Vitest** (+ jsdom) for unit / component tests.  
+- [ ] 🔍 (Optional) Configure **Jest + React-Testing-Library** for UI snapshot / smoke tests.
+
+## 1️⃣ Core Engine (`littlefaith-core`)
+- [ ] 🚧 Scaffold crate, expose `BibleDb::lookup(book, chap, verse)`.
+- [ ] 📦 Create **OSIS → SQLite compiler CLI** (`lf-compile`) with progress bar.
+- [ ] 🗃️ Design initial SQLite schema (`verses`, `metadata`, `fts_verses`).
+- [ ] 🔍 Implement **SQLite FTS5** search wrapper + simple boolean query parser.
+- [ ] 🧪 Unit tests: lookup accuracy, search hits, DB size sanity (< 10 MB for DR Bible).
+
+## 2️⃣ Data & Modules
+- [ ] 📥 Script to download public-domain Bibles (Douay-Rheims, Vulgate) + hash check.
+- [ ] 🔨 Batch-compile into `.bbmod` bundles; commit small sample under `/fixtures`.
+- [ ] 📝 Draft `manifest.toml` spec (canon, language, licence, versification).
+
+## 3️⃣ Frontend (React 19 + Vite + Radix UI + **shadcn/ui**)
+- [ ] ✨ `pnpm create tauri-app` – scaffold Tauri-React template.
+- [ ] 🖼️ Build split-pane skeleton: Sidebar ▸ BiblePane ▸ CommentaryPane.
+- [ ] 🪄 Install **Tailwind CSS** + **shadcn/ui** presets; add light/dark toggle.
+- [ ] 🧩 Implement Radix Tooltip via shadcn for verse hover preview.
+- [ ] ⌨️ Wire “Go To Verse” (`⌘/Ctrl + L`) → Rust `invoke("lookup")`.
+- [ ] 🔌 Integrate **React Query** for verse-fetch cache.
+- [ ] 🌐 Create **Zustand** store (`useLayoutStore`) for pane positions, theme, sidebar.
+
+## 4️⃣ DevOps & Automations
+- [ ] 🏗️ GitHub Actions matrix build (Win / macOS / Linux) + notarize macOS.
+- [ ] 📦 Draft `tauri.conf.json` for **auto-update** channel “alpha”.
+- [ ] ⌚ Nightly workflow: compile latest modules, run DB migrations, publish artifacts.
+- [ ] 🌧️ Proof-of-concept **Dropbox sync** task (Rust crate + OAuth).  
+- [ ] 🔐 Encrypt vault sync with **AES-CBC** before upload.
+
+## 5️⃣ AI Helper Scripts
+- [ ] ✏️ Prompt template for GPT “Generate React component docstrings”.
+- [ ] 🪛 CI comment-bot that suggests unit tests for new PRs.
+- [ ] 🗣️ Spike: natural-language → verse command (`/ask "Blessed are…"`) using core search.
+
+## 6️⃣ UX & Design
+- [ ] 🎨 Draft figma / wireframe: 3-pane study workspace + focus reading mode.
+- [ ] 💬 Decide default font stack (Noto-Serif + Noto-Sans for multilingual).
+- [ ] 🌍 Plan **i18n** pipeline (`react-i18next`, JSON locale files).
+
+## 7️⃣ Docs & Community
+- [ ] 📚 `docs/ARCHITECTURE.md` (high-level diagram).
+- [ ] 🐣 Write “Setting up dev env” guide (Rust toolchain + pnpm steps).
+- [ ] 🤝 Add `CODE_OF_CONDUCT.md` + `CONTRIBUTING.md`.
+- [ ] 🗳️ Open GitHub Discussions – seed “Module wishes” & “Design ideas” threads.
+
+## Icebox / Later
+- [ ] 🗺️ Map viewer plugin (Leaflet + BiblePlaces KML).
+- [ ] 🐑 Liturgy of the Hours feed importer.
+- [ ] 📲 Web-WASM edition POC (wasm-pack + SvelteKit static export).


### PR DESCRIPTION
## Summary
- replace DaisyUI with shadcn/ui in the tech stack table
- expand TODO list with detailed phase‑0 tasks

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687aa38ca220832797385c642bc6a6be