### PR TITLE
Add setup script for dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Rust dynamic-load or WASI. Examples: AI-chat assistant, Qur'an module, map viewe
 * **Web**: Same React code in Vite → deploy as PWA; point to WASM-compiled `littlefaith-core` (via `wasm-pack`).
 * **Mobile**: Capacitor wrapper later; or Flutter rewrite if full native is desired.
 
+## Development Setup
+
+Run `./setup.sh` to install Rust, Node.js, pnpm and the Tauri CLI. The script only installs missing tools.
+After running it, you can build the app with `cargo tauri dev` once the source code is available.
+
 ---
 
 LittleFaith aims for minimal footprint today with cathedral-level extensibility tomorrow.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# LittleFaith development environment setup
+set -e
+
+# Ensure the script works from repo root
+cd "$(dirname "$0")"
+
+install_rust() {
+    if ! command -v cargo >/dev/null 2>&1; then
+        echo "Installing Rust toolchain..."
+        curl https://sh.rustup.rs -sSf | sh -s -- -y
+        source "$HOME/.cargo/env"
+    else
+        echo "Rust already installed: $(rustc --version)"
+    fi
+}
+
+install_node() {
+    if ! command -v node >/dev/null 2>&1; then
+        echo "Installing Node via nvm..."
+        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+        export NVM_DIR="$HOME/.nvm"
+        [ -s "$NVM_DIR/nvm.sh" ] && \ . "$NVM_DIR/nvm.sh"
+        nvm install --lts
+    else
+        echo "Node already installed: $(node --version)"
+    fi
+}
+
+install_pnpm() {
+    if ! command -v pnpm >/dev/null 2>&1; then
+        echo "Installing pnpm..."
+        npm install -g pnpm
+    else
+        echo "pnpm already installed: $(pnpm --version)"
+    fi
+}
+
+install_tauri() {
+    if ! command -v cargo-tauri >/dev/null 2>&1; then
+        echo "Installing Tauri CLI..."
+        cargo install tauri-cli
+    else
+        echo "Tauri CLI already installed: $(cargo tauri --version)"
+    fi
+}
+
+install_rust
+install_node
+install_pnpm
+install_tauri
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add a `setup.sh` helper to install Rust, Node.js, pnpm and Tauri CLI
- document the new script in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687aad0b64ec8327aa578bc2cbd460ee