### PR TITLE
Clarify workflow docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,10 @@ Welcome! This repository currently contains documentation only. As the project g
 - Keep lines under 120 characters when possible.
 - Use Markdown headings and lists where appropriate.
 
+## Automation Workflow
+- Run `./setup.sh` to install required tools before building.
+- Update `TODO.md` as tasks are completed or added.
+- Document notable changes in `CHANGELOG.md` under the "Unreleased" section.
+- Keep commit messages and PR descriptions clear for automated summaries.
+- Keep `setup.sh` and any tests current as improvements are discovered.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Initial documentation and repository scaffolding.
+- Clarify automation workflow in AGENTS and CONTRIBUTING.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,17 @@ Thank you for considering contributing to LittleFaith!
 
 ## Development Setup
 
-1. Install [Rust](https://www.rust-lang.org/) and [Node.js](https://nodejs.org/).
+1. Run `./setup.sh` to install Rust, Node and the Tauri CLI.
 2. Clone the repository and install JavaScript dependencies with `npm install` if a `package.json` exists.
 3. Build the desktop app using `cargo tauri dev`.
+
+If you add new dependencies or tools, update `setup.sh` so others can reproduce the environment.
+
+## Workflow
+- Use `TODO.md` to track tasks and check off completed items.
+- Document user-facing changes in `CHANGELOG.md`.
+- Keep docs and comments concise so automated tools can summarize them.
+- Update tests and `setup.sh` whenever you improve the development workflow.
 
 ## Pull Requests
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # LittleFaith development environment setup
+# Keep this script updated when new tools are needed.
 set -e
 
 # Ensure the script works from repo root


### PR DESCRIPTION
## Summary
- mention keeping `setup.sh` and tests current in AGENTS
- call out updating `setup.sh` in CONTRIBUTING workflow
- update CHANGELOG
- note in setup script header to keep it current

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687aaf8dfc0c83278c3f913845713483